### PR TITLE
fix lzo import error

### DIFF
--- a/src/libs/mdict/mdict_query.py
+++ b/src/libs/mdict/mdict_query.py
@@ -16,7 +16,7 @@ from .readmdict import MDD, MDX
 
 # LZO compression is used for engine version < 2.0
 try:
-    import lzo
+    from . import lzo
 except ImportError:
     lzo = None
     #print("LZO compression support is not available")

--- a/src/libs/mdict/readmdict.py
+++ b/src/libs/mdict/readmdict.py
@@ -30,7 +30,7 @@ from .pureSalsa20 import Salsa20
 import zlib
 # LZO compression is used for engine version < 2.0
 try:
-    import lzo
+    from . import lzo
 except ImportError:
     lzo = None
     print("LZO compression support is not available")


### PR DESCRIPTION
mdict_query.py 的 import lzo 必定报错 `ImportError: No module named 'lzo'`，导致有些词典不能用（我主要试了一些日语词典，比如`《小学馆V2日汉辞典》.mdx`），将两处 import 改为正确的格式就能用了